### PR TITLE
Add edges field, refactor for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: java
+jdk:
+  - oraclejdk8
+
+before_install:
+  - git clone https://github.com/SciGraph/SciGraph; cd SciGraph; mvn -DskipTests -DskipITs install; cd ..
+
+after_success:
+  - mvn clean

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/SciGraph/golr-loader.svg?branch=master)](https://travis-ci.org/SciGraph/golr-loader)
+
 # golr-loader
 
 Convert [SciGraph](https://github.com/SciGraph/SciGraph) query results into JSON 

--- a/src/main/java/org/monarch/golr/SimpleLoaderMain.java
+++ b/src/main/java/org/monarch/golr/SimpleLoaderMain.java
@@ -1,7 +1,6 @@
 package org.monarch.golr;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 import java.util.Optional;
 
 import org.apache.commons.cli.CommandLine;
@@ -53,10 +52,17 @@ public class SimpleLoaderMain {
     CommandLine cmd;
     Neo4jConfiguration neo4jConfig = null;
     Optional<String> outputFile = Optional.empty();
+    Writer writer = null;
+    boolean hasOutputFile = false;
+
     try {
       cmd = parser.parse(options, args);
       if (cmd.hasOption("o")) {
         outputFile = Optional.of(cmd.getOptionValue("o"));
+        writer = new FileWriter(new File(outputFile.get()));
+        hasOutputFile = true;
+      } else {
+        writer = new StringWriter();
       }
       neo4jConfig = mapper.readValue(new File(cmd.getOptionValue("g")), Neo4jConfiguration.class);
     } catch (ParseException e) {
@@ -69,7 +75,12 @@ public class SimpleLoaderMain {
     SimpleLoader loader = i.getInstance(SimpleLoader.class);
 
     Stopwatch sw = Stopwatch.createStarted();
-    loader.generate(outputFile);
+    loader.generate(writer);
+
+    if (!hasOutputFile) {
+      System.out.println(writer.toString());
+    }
+
     System.out.println("Completed in " + sw.stop());
 
   }

--- a/src/test/java/org/monarch/golr/GolrLoaderTest.java
+++ b/src/test/java/org/monarch/golr/GolrLoaderTest.java
@@ -34,7 +34,8 @@ public class GolrLoaderTest extends GolrLoadSetup {
     CypherUtil cypherUtil = new CypherUtil(graphDb, curieUtil);
     processor =
         new GolrLoader(graphDb, graph, new CypherUtil(graphDb, curieUtil), curieUtil, 
-            stub, new GraphApi(graphDb, cypherUtil, curieUtil));  }
+            stub, new GraphApi(graphDb, cypherUtil, curieUtil));
+  }
 
   @Test
   public void primitiveTypesSerialize() throws Exception {

--- a/src/test/java/org/monarch/golr/SimpleLoadSetup.java
+++ b/src/test/java/org/monarch/golr/SimpleLoadSetup.java
@@ -1,0 +1,64 @@
+package org.monarch.golr;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.prefixcommons.CurieUtil;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+
+import io.scigraph.frames.CommonProperties;
+import io.scigraph.frames.NodeProperties;
+import io.scigraph.owlapi.OwlRelationships;
+
+public class SimpleLoadSetup extends io.scigraph.util.GraphTestBase {
+
+    static Node a, b, c, d, e, f;
+    static CurieUtil curieUtil;
+    static ClosureUtil closureUtil;
+    static Map<String, String> curieMap = new HashMap<>();
+
+    static String getFixture(String name) throws IOException {
+        URL url = Resources.getResource(name);
+        return Resources.toString(url, Charsets.UTF_8);
+    }
+
+    static void populateGraph(GraphDatabaseService graphDb) {
+        try (Transaction tx = graphDb.beginTx()) {
+
+            Node gene = createNode("http://x.org/geneA");
+            gene.setProperty(NodeProperties.LABEL, "SHH");
+            gene.addLabel(Label.label("gene"));
+            gene.addLabel(Label.label("cliqueLeader"));
+            Node taxa = createNode("http://x.org/taxa");
+            taxa.setProperty(NodeProperties.LABEL, "Homo sapiens");
+            taxa.addLabel(Label.label("organism"));
+            taxa.addLabel(Label.label("cliqueLeader"));
+            Node geneB = createNode("http://x.org/geneB");
+            gene.createRelationshipTo(taxa, RelationshipType.withName("http://purl.obolibrary.org/obo/RO_0002162"));
+            gene.createRelationshipTo(geneB, RelationshipType.withName("http://purl.obolibrary.org/obo/RO_0002435"));
+
+
+            tx.success();
+        }
+    }
+
+    @BeforeClass
+    public static void buildGraph() {
+        populateGraph(graphDb);
+        curieMap.put("X", "http://x.org/");
+        curieUtil = new CurieUtil(curieMap);
+        closureUtil = new ClosureUtil(graphDb, curieUtil);
+    }
+
+}

--- a/src/test/java/org/monarch/golr/SimpleLoaderTest.java
+++ b/src/test/java/org/monarch/golr/SimpleLoaderTest.java
@@ -1,0 +1,33 @@
+package org.monarch.golr;
+
+import io.scigraph.internal.CypherUtil;
+import io.scigraph.internal.GraphApi;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+public class SimpleLoaderTest extends SimpleLoadSetup {
+
+    SimpleLoader processor;
+    StringWriter writer = new StringWriter();
+
+    @Before
+    public void setup() throws IOException {
+        CypherUtil cypherUtil = new CypherUtil(graphDb, curieUtil);
+        processor =
+                new SimpleLoader(graphDb, graph, new CypherUtil(graphDb, curieUtil), curieUtil,
+                        new GraphApi(graphDb, cypherUtil, curieUtil));
+    }
+
+    @Test
+    public void testJSONDocument() throws Exception {
+        Writer writer = new StringWriter();
+        processor.generate(writer);
+        JSONAssert.assertEquals(getFixture("fixtures/searchDoc.json"), writer.toString(), JSONCompareMode.NON_EXTENSIBLE);
+    }
+}

--- a/src/test/resources/fixtures/searchDoc.json
+++ b/src/test/resources/fixtures/searchDoc.json
@@ -1,0 +1,32 @@
+[
+  {
+    "iri":"http://x.org/geneA",
+    "id":"X:geneA",
+    "prefix":"X",
+    "label":[
+      "SHH"
+    ],
+    "definition":[
+
+    ],
+    "synonym":[
+
+    ],
+    "edges":2,
+    "taxon":"X:taxa",
+    "taxon_label":"Homo sapiens",
+    "taxon_label_synonym":[
+
+    ],
+    "category":[
+      "gene"
+    ],
+    "equivalent_iri":[
+
+    ],
+    "equivalent_curie":[
+
+    ],
+    "leaf":true
+  }
+]


### PR DESCRIPTION
Adds curie prefix and count of edges to SimpleLoader (search and autocomplete).  Prefix mappings are useful for filtering in addition to category.  Edge count may be useful in faceted/scoped autocomplete to adjust rankings.