### PR TITLE
Added missing dependency for testcases and java9 support in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,23 @@
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.neo4j.test</groupId>
+			<artifactId>neo4j-harness</artifactId>
+			<version>3.3.1</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.sun.jersey</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.sun.jersey.contribs</groupId>
+					<artifactId>jersey-multipart</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 		<dependency>
 			<groupId>org.skyscreamer</groupId>
 			<artifactId>jsonassert</artifactId>
@@ -144,6 +160,15 @@
 	</build>
 
 	<profiles>
+		<profile>
+			<id>java9</id>
+			<activation>
+				<jdk>9</jdk>
+			</activation>
+			<properties>
+				<java.version>9</java.version>
+			</properties>
+		</profile>
 		<profile>
 			<id>Java8</id>
 			<activation>


### PR DESCRIPTION
1. I tested the branch in Kent's [PR](https://github.com/SciGraph/golr-loader/pull/37) but still failed to compile; the main package was fine but the test package had issues. 
~~~~
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /home/yy20716/eclipse-workspace/golr-loader/src/test/java/org/monarch/golr/GolrLoadSetup.java:[112,5] cannot access org.neo4j.test.rule.ExternalResource
  class file for org.neo4j.test.rule.ExternalResource not found
[INFO] 1 error
~~~~
  
   Based on [the other Kent's commit](https://github.com/SciGraph/SciGraph/pull/254/files#diff-600376dffeb79835ede4a0b285078036R263), I added a dependency entry in pom.xml to solve that error. 

1. I also added Java 9 entry, i.e. I was using Java 9 but the previous pom.xml did not have the entry for java 9, so simply added the entry to run codes. 