### PR TITLE
Fix for invalid signature file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,16 @@
 							<goal>shade</goal>
 						</goals>
 						<configuration>
+                                                    <filters>
+                                                        <filter>
+                                                            <artifact>*:*</artifact>
+                                                                <excludes>
+                                                                    <exclude>META-INF/*.SF</exclude>
+                                                                    <exclude>META-INF/*.DSA</exclude>
+                                                                    <exclude>META-INF/*.RSA</exclude>
+                                                                </excludes>
+                                                        </filter>
+                                                    </filters>
 							<transformers>
 								<transformer
 									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
When generating a jar from the latest build using the maven-shade plugin we get the error:

    Error: A JNI error has occurred, please check your installation and try again
    Exception in thread "main" java.lang.SecurityException: Invalid signature file digest for Manifest main attributes

jar -tvf ./target/golr-loader-0.0.1-SNAPSHOT.jar | grep -i \\.dsa
  5865 Mon Mar 05 10:19:24 PST 2018 META-INF/BCKEY.DSA

This might be related to adding neo4j-harness, but it is only in the test scope.

I've added a filter to the shade plugin that excludes SF, DSA, and RSA files, are there any security consequences from doing this?