### PR TITLE
Add all clique leaders to simple loader

### DIFF
--- a/src/main/java/org/monarch/golr/SimpleLoader.java
+++ b/src/main/java/org/monarch/golr/SimpleLoader.java
@@ -49,7 +49,7 @@ public class SimpleLoader {
   private static final Logger logger = Logger.getLogger(SimpleLoader.class.getName());
   private final String cliqueLeaderString = "cliqueLeader";
   private final Label cliqueLeaderLabel = Label.label(cliqueLeaderString);
-  private final Set<String> labels = Sets.newHashSet("Phenotype", "disease", "gene");
+  private final Set<String> labels = Sets.newHashSet("Phenotype", "disease", "gene", "sequence feature");
 
   GraphDatabaseService graphDb;
   Graph graph;

--- a/src/main/java/org/monarch/golr/SimpleLoader.java
+++ b/src/main/java/org/monarch/golr/SimpleLoader.java
@@ -69,7 +69,7 @@ public class SimpleLoader {
     this.cypherUtil = cypherUtil;
     this.curieUtil = curieUtil;
     this.api = api;
-    unwantedLabels = new HashSet<String>();
+    unwantedLabels = new HashSet<String>(labels);
     unwantedLabels.add(cliqueLeaderString);
   }
 
@@ -89,10 +89,13 @@ public class SimpleLoader {
       ResourceIterator<Node> cliqueLeaderNodes = graphDb.findNodes(cliqueLeaderLabel);
       while (cliqueLeaderNodes.hasNext()) {
         Node baseNode = cliqueLeaderNodes.next();
+        String iri = GraphUtil.getProperty(baseNode, NodeProperties.IRI, String.class).get();
+
         // consider only nodes with a label property and in the category set
-        if (baseNode.hasProperty(NodeProperties.LABEL)) {
+        if (baseNode.hasProperty(NodeProperties.LABEL)
+                && !iri.startsWith("_:")
+                && !iri.startsWith("https://monarchinitiative.org/.well-known/genid/")) {
           generator.writeStartObject();
-          String iri = GraphUtil.getProperty(baseNode, NodeProperties.IRI, String.class).get();
           generator.writeStringField("iri", iri);
           generator.writeStringField("id", curieUtil.getCurie(iri).orElse(iri));
           // Get curie prefix

--- a/src/main/java/org/monarch/golr/SimpleLoader.java
+++ b/src/main/java/org/monarch/golr/SimpleLoader.java
@@ -49,8 +49,7 @@ public class SimpleLoader {
   private static final Logger logger = Logger.getLogger(SimpleLoader.class.getName());
   private final String cliqueLeaderString = "cliqueLeader";
   private final Label cliqueLeaderLabel = Label.label(cliqueLeaderString);
-  private final Set<String> labels = Sets.newHashSet("Phenotype", "disease", "gene",
-                                                     "sequence feature", "genotype", "anatomical entity");
+  private final Set<String> labels = Sets.newHashSet("Node");
 
   GraphDatabaseService graphDb;
   Graph graph;
@@ -165,8 +164,7 @@ public class SimpleLoader {
 
           // categories
           writeOptionalArray("category", generator,
-              Lists.newArrayList(baseNode.getLabels()).stream()
-                  .filter(label -> labels.contains(label.name())).collect(Collectors.toList()));
+              Lists.newArrayList(baseNode.getLabels()).stream());
 
           // equivalences
           List<String> equivalences = new ArrayList<String>();

--- a/src/main/java/org/monarch/golr/SimpleLoader.java
+++ b/src/main/java/org/monarch/golr/SimpleLoader.java
@@ -90,8 +90,7 @@ public class SimpleLoader {
       while (cliqueLeaderNodes.hasNext()) {
         Node baseNode = cliqueLeaderNodes.next();
         // consider only nodes with a label property and in the category set
-        if (isInLabelSet(baseNode.getLabels(), labels)
-            && baseNode.hasProperty(NodeProperties.LABEL)) {
+        if (baseNode.hasProperty(NodeProperties.LABEL)) {
           generator.writeStartObject();
           String iri = GraphUtil.getProperty(baseNode, NodeProperties.IRI, String.class).get();
           generator.writeStringField("iri", iri);
@@ -164,7 +163,7 @@ public class SimpleLoader {
 
           // categories
           writeOptionalArray("category", generator,
-              Lists.newArrayList(baseNode.getLabels());
+              Lists.newArrayList(baseNode.getLabels()));
 
           // equivalences
           List<String> equivalences = new ArrayList<String>();

--- a/src/main/java/org/monarch/golr/SimpleLoader.java
+++ b/src/main/java/org/monarch/golr/SimpleLoader.java
@@ -49,7 +49,8 @@ public class SimpleLoader {
   private static final Logger logger = Logger.getLogger(SimpleLoader.class.getName());
   private final String cliqueLeaderString = "cliqueLeader";
   private final Label cliqueLeaderLabel = Label.label(cliqueLeaderString);
-  private final Set<String> labels = Sets.newHashSet("Phenotype", "disease", "gene", "sequence feature");
+  private final Set<String> labels = Sets.newHashSet("Phenotype", "disease", "gene",
+                                                     "sequence feature", "genotype", "anatomical entity");
 
   GraphDatabaseService graphDb;
   Graph graph;

--- a/src/main/java/org/monarch/golr/SimpleLoader.java
+++ b/src/main/java/org/monarch/golr/SimpleLoader.java
@@ -164,7 +164,7 @@ public class SimpleLoader {
 
           // categories
           writeOptionalArray("category", generator,
-              Lists.newArrayList(baseNode.getLabels()).stream());
+              Lists.newArrayList(baseNode.getLabels());
 
           // equivalences
           List<String> equivalences = new ArrayList<String>();

--- a/src/main/java/org/monarch/golr/SimpleLoader.java
+++ b/src/main/java/org/monarch/golr/SimpleLoader.java
@@ -47,17 +47,18 @@ import io.scigraph.owlapi.OwlRelationships;
 public class SimpleLoader {
 
   private static final Logger logger = Logger.getLogger(SimpleLoader.class.getName());
-  private final String cliqueLeaderString = "cliqueLeader";
-  private final Label cliqueLeaderLabel = Label.label(cliqueLeaderString);
-  private final Set<String> labels = Sets.newHashSet("Node");
+  private final Label cliqueLeaderLabel = Label.label("cliqueLeader");
+  private final Set<String> unwantedLabels = Sets.newHashSet("cliqueLeader",
+                                                             "Node",
+                                                             "Class",
+                                                             "NamedIndividual");
 
   GraphDatabaseService graphDb;
   Graph graph;
   CypherUtil cypherUtil;
   CurieUtil curieUtil;
   GraphApi api;
-  Set<String> unwantedLabels;
-  
+
 
   Set<String> tmp = new HashSet<String>();
 
@@ -69,8 +70,6 @@ public class SimpleLoader {
     this.cypherUtil = cypherUtil;
     this.curieUtil = curieUtil;
     this.api = api;
-    unwantedLabels = new HashSet<String>(labels);
-    unwantedLabels.add(cliqueLeaderString);
   }
 
   private static final RelationshipType inTaxon =

--- a/src/test/java/org/monarch/golr/SimpleLoadSetup.java
+++ b/src/test/java/org/monarch/golr/SimpleLoadSetup.java
@@ -39,6 +39,7 @@ public class SimpleLoadSetup extends io.scigraph.util.GraphTestBase {
             Node gene = createNode("http://x.org/geneA");
             gene.setProperty(NodeProperties.LABEL, "SHH");
             gene.addLabel(Label.label("gene"));
+            gene.addLabel(Label.label("Node"));
             gene.addLabel(Label.label("cliqueLeader"));
             Node taxa = createNode("http://x.org/taxa");
             taxa.setProperty(NodeProperties.LABEL, "Homo sapiens");
@@ -47,6 +48,14 @@ public class SimpleLoadSetup extends io.scigraph.util.GraphTestBase {
             Node geneB = createNode("http://x.org/geneB");
             gene.createRelationshipTo(taxa, RelationshipType.withName("http://purl.obolibrary.org/obo/RO_0002162"));
             gene.createRelationshipTo(geneB, RelationshipType.withName("http://purl.obolibrary.org/obo/RO_0002435"));
+
+            Node bnode1 = createNode("_:1234");
+            bnode1.setProperty(NodeProperties.LABEL, "some bnode");
+            bnode1.addLabel(Label.label("cliqueLeader"));
+
+            Node bnode2 = createNode("https://monarchinitiative.org/.well-known/genid/121002-41751VL");
+            bnode2.setProperty(NodeProperties.LABEL, "bnode variant");
+            bnode2.addLabel(Label.label("cliqueLeader"));
 
 
             tx.success();

--- a/src/test/resources/fixtures/searchDoc.json
+++ b/src/test/resources/fixtures/searchDoc.json
@@ -28,5 +28,35 @@
 
     ],
     "leaf":true
+  },
+  {
+    "iri":"http://x.org/taxa",
+    "id":"X:taxa",
+    "prefix":"X",
+    "label":[
+      "Homo sapiens"
+    ],
+    "definition":[
+
+    ],
+    "synonym":[
+
+    ],
+    "edges":1,
+    "taxon":"",
+    "taxon_label":"",
+    "taxon_label_synonym":[
+
+    ],
+    "category":[
+      "organism"
+    ],
+    "equivalent_iri":[
+
+    ],
+    "equivalent_curie":[
+
+    ],
+    "leaf":true
   }
 ]


### PR DESCRIPTION
Indexes all clique leaders into our solr search core instead of a subset of types - formerly gene, disease, phenotype.

Should we index all nodes? see https://github.com/SciGraph/golr-loader/issues/41