### PR TITLE
Support equivalent curie mappings

### DIFF
--- a/src/main/java/org/monarch/golr/SimpleLoader.java
+++ b/src/main/java/org/monarch/golr/SimpleLoader.java
@@ -181,6 +181,17 @@ public class SimpleLoader {
           writeOptionalArray("equivalent_iri", generator, equivalences);
 
           List<String> equivalentCuries = new ArrayList<>();
+
+          if (curie.isPresent()) {
+            String[] parts = curie.get().split(":");
+            String prefix = parts[0];
+            String reference = parts[1];
+            if (eqCurieMap.containsKey(prefix)) {
+              for (String eqPrefix : eqCurieMap.get(prefix)) {
+                equivalentCuries.add(eqPrefix + ":" +  reference);
+              }
+            }
+          }
           for (String equivalentIri : equivalences) {
             // Get curie prefix
             Optional<String> eqCurie = curieUtil.getCurie(equivalentIri);
@@ -197,7 +208,6 @@ public class SimpleLoader {
             } else {
               equivalentCuries.add(equivalentIri);
             }
-
           }
 
           writeOptionalArray("equivalent_curie", generator, equivalentCuries);

--- a/src/test/java/org/monarch/golr/SimpleLoadSetup.java
+++ b/src/test/java/org/monarch/golr/SimpleLoadSetup.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+
 
 import org.junit.BeforeClass;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -27,6 +30,7 @@ public class SimpleLoadSetup extends io.scigraph.util.GraphTestBase {
     static CurieUtil curieUtil;
     static ClosureUtil closureUtil;
     static Map<String, String> curieMap = new HashMap<>();
+    static Map<String, List<String>> eqCurieMap = new HashMap<>();
 
     static String getFixture(String name) throws IOException {
         URL url = Resources.getResource(name);
@@ -57,6 +61,8 @@ public class SimpleLoadSetup extends io.scigraph.util.GraphTestBase {
             bnode2.setProperty(NodeProperties.LABEL, "bnode variant");
             bnode2.addLabel(Label.label("cliqueLeader"));
 
+            Node eqGene = createNode("http://x.org/eqGeneA");
+            gene.createRelationshipTo(eqGene, OwlRelationships.OWL_SAME_AS);
 
             tx.success();
         }
@@ -66,6 +72,9 @@ public class SimpleLoadSetup extends io.scigraph.util.GraphTestBase {
     public static void buildGraph() {
         populateGraph(graphDb);
         curieMap.put("X", "http://x.org/");
+        List<String> eq = new ArrayList<>();
+        eq.add("Y");
+        eqCurieMap.put("X", eq);
         curieUtil = new CurieUtil(curieMap);
         closureUtil = new ClosureUtil(graphDb, curieUtil);
     }

--- a/src/test/java/org/monarch/golr/SimpleLoaderTest.java
+++ b/src/test/java/org/monarch/golr/SimpleLoaderTest.java
@@ -27,7 +27,7 @@ public class SimpleLoaderTest extends SimpleLoadSetup {
     @Test
     public void testJSONDocument() throws Exception {
         Writer writer = new StringWriter();
-        processor.generate(writer);
+        processor.generate(writer, eqCurieMap);
         JSONAssert.assertEquals(getFixture("fixtures/searchDoc.json"), writer.toString(), JSONCompareMode.NON_EXTENSIBLE);
     }
 }

--- a/src/test/resources/fixtures/searchDoc.json
+++ b/src/test/resources/fixtures/searchDoc.json
@@ -26,7 +26,8 @@
     ],
     "equivalent_curie":[
       "X:eqGeneA",
-      "Y:eqGeneA"
+      "Y:eqGeneA",
+      "Y:geneA"
     ],
     "leaf":true
   },
@@ -56,7 +57,7 @@
 
     ],
     "equivalent_curie":[
-
+      "Y:taxa"
     ],
     "leaf":true
   }

--- a/src/test/resources/fixtures/searchDoc.json
+++ b/src/test/resources/fixtures/searchDoc.json
@@ -12,7 +12,7 @@
     "synonym":[
 
     ],
-    "edges":2,
+    "edges":3,
     "taxon":"X:taxa",
     "taxon_label":"Homo sapiens",
     "taxon_label_synonym":[
@@ -22,10 +22,11 @@
       "gene"
     ],
     "equivalent_iri":[
-
+      "http://x.org/eqGeneA"
     ],
     "equivalent_curie":[
-
+      "X:eqGeneA",
+      "Y:eqGeneA"
     ],
     "leaf":true
   },


### PR DESCRIPTION
Add support for an optional yaml mapping that specifies equivalent curie prefixes, ie FB:1234 and FlyBase:1234