### PR TITLE
Remove iri and equivalent iri from simple loader

### DIFF
--- a/src/main/java/org/monarch/golr/SimpleLoader.java
+++ b/src/main/java/org/monarch/golr/SimpleLoader.java
@@ -96,7 +96,6 @@ public class SimpleLoader {
                 && !iri.startsWith("_:")
                 && !iri.startsWith("https://monarchinitiative.org/.well-known/genid/")) {
           generator.writeStartObject();
-          generator.writeStringField("iri", iri);
           generator.writeStringField("id", curieUtil.getCurie(iri).orElse(iri));
           // Get curie prefix
           Optional<String> curie = curieUtil.getCurie(iri);
@@ -178,7 +177,6 @@ public class SimpleLoader {
                   GraphUtil.getProperty(path.endNode(), NodeProperties.IRI, String.class).get());
             }
           }
-          writeOptionalArray("equivalent_iri", generator, equivalences);
 
           List<String> equivalentCuries = new ArrayList<>();
 

--- a/src/test/resources/fixtures/searchDoc.json
+++ b/src/test/resources/fixtures/searchDoc.json
@@ -1,6 +1,5 @@
 [
   {
-    "iri":"http://x.org/geneA",
     "id":"X:geneA",
     "prefix":"X",
     "label":[
@@ -21,9 +20,6 @@
     "category":[
       "gene"
     ],
-    "equivalent_iri":[
-      "http://x.org/eqGeneA"
-    ],
     "equivalent_curie":[
       "X:eqGeneA",
       "Y:eqGeneA",
@@ -32,7 +28,6 @@
     "leaf":true
   },
   {
-    "iri":"http://x.org/taxa",
     "id":"X:taxa",
     "prefix":"X",
     "label":[
@@ -52,9 +47,6 @@
     ],
     "category":[
       "organism"
-    ],
-    "equivalent_iri":[
-
     ],
     "equivalent_curie":[
       "Y:taxa"


### PR DESCRIPTION
Removing IRIs from the search index, see https://github.com/monarch-initiative/monarch-ui/issues/63

Fixes https://github.com/SciGraph/golr-loader/issues/45