### PR TITLE
Optimizations to golr loader, removes MapDB

### DIFF
--- a/src/main/java/org/monarch/golr/GolrLoader.java
+++ b/src/main/java/org/monarch/golr/GolrLoader.java
@@ -392,7 +392,7 @@ public class GolrLoader {
       if (recordCount == 0) {
         lastPair = new Pair<>(subjectIri, objectIri);
       }
-      if (!pair.equals(lastPair)){
+      if (!pair.equals(lastPair) || !result.hasNext()){
 
         if (resultGraph != null) {
           com.tinkerpop.blueprints.Graph evidenceGraph =
@@ -411,7 +411,6 @@ public class GolrLoader {
 
             List<Closure> evidenceClosure = processor.getEvidence(evidenceGraph);
             docUtil.writeQuint(EVIDENCE_FIELD, evidenceClosure, resultDoc);
-
           }
 
           List<Closure> sourceClosure = processor.getSource(evidenceGraph);
@@ -437,14 +436,11 @@ public class GolrLoader {
         Set<Long> ignoredNodes = new HashSet<>();
         Writer stringWriter = new StringWriter();
         JsonGenerator stringGenerator = new JsonFactory().createGenerator(stringWriter);
-        boolean emitEvidence = true;
         TinkerGraphUtil tguEvidenceGraph = new TinkerGraphUtil(curieUtil);
 
         stringGenerator.writeStartObject();
-
         resultDoc = serializerRow(row, tguEvidenceGraph, ignoredNodes, query);
-
-        resultGraph = new EvidenceGraphInfo(tguEvidenceGraph.getGraph(), emitEvidence, ignoredNodes);
+        resultGraph = new EvidenceGraphInfo(tguEvidenceGraph.getGraph(), true, ignoredNodes);
       } else {
         pairCount++;
         TinkerGraphUtil tguEvidenceGraph = new TinkerGraphUtil(EvidenceGraphInfo.toGraph(resultGraph.graphBytes), curieUtil);

--- a/src/main/java/org/monarch/golr/QueriesSanityCheck.java
+++ b/src/main/java/org/monarch/golr/QueriesSanityCheck.java
@@ -35,7 +35,7 @@ import io.scigraph.internal.CypherUtil;
 public class QueriesSanityCheck {
 
   private final static ExecutorService timeoutExecutorService =
-      Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() / 2);
+      Executors.newFixedThreadPool(5);
   private final static int timeout = 5; // in hours
 
   public static void main(String[] args)


### PR DESCRIPTION
The golr loader currently takes 30 hours to load all documents *excluding* optimizing, moving files, setup/teardown on the 201902 release of scigraph, using the queries on https://github.com/monarch-initiative/monarch-cypher-queries/tree/60a3cf

This update improves the load time to 16 and a half hours with the following updates:
- Replaces all UNION queries with COLLECT and ordering the output by subject, object
- Removes the need for MapDB to store all neo4j results for each query and then sorting, instead receives the sorted data and operates on it accordingly
- Increase batch commit size from 1k to 10k docs
- Decrease n threads from all avail processors to 7
- Increase java heap max on golr loader from 90G to 300G
- Increase neo4j pagecache from 50G to 100G
- Increase Jetty idle timeout from 50 seconds to 200
- Increase solr heap max from 4G to 10G

The downside is that we monopolize all the memory on one of our servers for ~8 hours.

See the accompanying PRs:
https://github.com/monarch-initiative/monarch-cypher-queries/pull/33
https://github.com/monarch-initiative/solr-docker-monarch-golr/pull/1