### PR TITLE
Add equivalent closure, adjust taxon inference path

### DIFF
--- a/src/main/java/org/monarch/golr/GolrLoader.java
+++ b/src/main/java/org/monarch/golr/GolrLoader.java
@@ -554,6 +554,7 @@ public class GolrLoader {
       String[] cypherRels = types.split("\\|");
       for (String cypherRel : cypherRels) {
         String unquotedCypherRel = cypherRel.replaceAll("^`|`$","");
+        unquotedCypherRel = curieUtil.getIri(unquotedCypherRel).orElse(unquotedCypherRel);
         RelationshipType relType = RelationshipType.withName(unquotedCypherRel);
         DirectedRelationshipType dirRelType = new DirectedRelationshipType(relType, Direction.OUTGOING);
         rels.add(dirRelType);
@@ -641,28 +642,32 @@ public class GolrLoader {
           closureTypes.addAll(docUtil.DEFAULT_CLOSURE_TYPES);
           if ("subject".equals(key) && query.getSubjectClosure() != null) {
             Set<DirectedRelationshipType> rels = resolveRelationships("subject_closure", query.getSubjectClosure());
+            closureTypes.clear();
             closureTypes.addAll(rels);
 
             // Add all equivalent IDs to subject
             List<Closure> closures = new ArrayList<>();
             closures.add(closureUtil.getClosure((Node) value, docUtil.EQUIVALENT_EDGES));
-            docUtil.addClosure("subject_eq", ClosureUtil.collectIds(closures), doc);
+            docUtil.addClosure("subject_eq", ClosureUtil.collectIdClosure(closures), doc);
           }
           if ("object".equals(key) && query.getObjectClosure() != null) {
             Set<DirectedRelationshipType> rels = resolveRelationships("object_closure", query.getObjectClosure());
+            closureTypes.clear();
             closureTypes.addAll(rels);
 
             // Add all equivalent IDs to object
             List<Closure> closures = new ArrayList<>();
             closures.add(closureUtil.getClosure((Node) value, docUtil.EQUIVALENT_EDGES));
-            docUtil.addClosure("object_eq", ClosureUtil.collectIds(closures), doc);
+            docUtil.addClosure("object_eq", ClosureUtil.collectIdClosure(closures), doc);
           }
           if ("relation".equals(key) && query.getRelationClosure() != null) {
             Set<DirectedRelationshipType> rels = resolveRelationships("relation_closure", query.getRelationClosure());
+            closureTypes.clear();
             closureTypes.addAll(rels);
           }
           if ("evidence".equals(key) && query.getEvidenceClosure() != null) {
             Set<DirectedRelationshipType> rels = resolveRelationships("evidence_closure", query.getEvidenceClosure());
+            closureTypes.clear();
             closureTypes.addAll(rels);
           }
           docUtil.addNodes(key, singleton((Node) value), closureTypes, doc);

--- a/src/main/java/org/monarch/golr/GolrLoader.java
+++ b/src/main/java/org/monarch/golr/GolrLoader.java
@@ -161,7 +161,7 @@ public class GolrLoader {
         .relationships(OwlRelationships.RDF_TYPE, Direction.OUTGOING)
         .relationships(inTaxon, Direction.OUTGOING).uniqueness(Uniqueness.RELATIONSHIP_GLOBAL);
     for (RelationshipType part_of : parts_of) {
-      taxonDescription = taxonDescription.relationships(part_of, Direction.OUTGOING);
+      taxonDescription = taxonDescription.relationships(part_of, Direction.BOTH);
     }
     for (RelationshipType subSequenceOf : subSequenceOfs) {
       taxonDescription = taxonDescription.relationships(subSequenceOf, Direction.INCOMING);
@@ -642,10 +642,20 @@ public class GolrLoader {
           if ("subject".equals(key) && query.getSubjectClosure() != null) {
             Set<DirectedRelationshipType> rels = resolveRelationships("subject_closure", query.getSubjectClosure());
             closureTypes.addAll(rels);
+
+            // Add all equivalent IDs to subject
+            List<Closure> closures = new ArrayList<>();
+            closures.add(closureUtil.getClosure((Node) value, docUtil.EQUIVALENT_EDGES));
+            docUtil.addClosure("subject_eq", ClosureUtil.collectIds(closures), doc);
           }
           if ("object".equals(key) && query.getObjectClosure() != null) {
             Set<DirectedRelationshipType> rels = resolveRelationships("object_closure", query.getObjectClosure());
             closureTypes.addAll(rels);
+
+            // Add all equivalent IDs to object
+            List<Closure> closures = new ArrayList<>();
+            closures.add(closureUtil.getClosure((Node) value, docUtil.EQUIVALENT_EDGES));
+            docUtil.addClosure("object_eq", ClosureUtil.collectIds(closures), doc);
           }
           if ("relation".equals(key) && query.getRelationClosure() != null) {
             Set<DirectedRelationshipType> rels = resolveRelationships("relation_closure", query.getRelationClosure());

--- a/src/main/java/org/monarch/golr/GolrLoader.java
+++ b/src/main/java/org/monarch/golr/GolrLoader.java
@@ -561,7 +561,7 @@ public class GolrLoader {
             || relType.equals(OwlRelationships.OWL_SAME_AS)) {
           direction = Direction.BOTH;
         }
-        DirectedRelationshipType dirRelType = new DirectedRelationshipType(relType, Direction.OUTGOING);
+        DirectedRelationshipType dirRelType = new DirectedRelationshipType(relType, direction);
         rels.add(dirRelType);
       }
     }

--- a/src/main/java/org/monarch/golr/GolrLoader.java
+++ b/src/main/java/org/monarch/golr/GolrLoader.java
@@ -556,6 +556,11 @@ public class GolrLoader {
         String unquotedCypherRel = cypherRel.replaceAll("^`|`$","");
         unquotedCypherRel = curieUtil.getIri(unquotedCypherRel).orElse(unquotedCypherRel);
         RelationshipType relType = RelationshipType.withName(unquotedCypherRel);
+        Direction direction = Direction.OUTGOING;
+        if (relType.equals(OwlRelationships.OWL_EQUIVALENT_CLASS)
+            || relType.equals(OwlRelationships.OWL_SAME_AS)) {
+          direction = Direction.BOTH;
+        }
         DirectedRelationshipType dirRelType = new DirectedRelationshipType(relType, Direction.OUTGOING);
         rels.add(dirRelType);
       }
@@ -639,7 +644,7 @@ public class GolrLoader {
         }
         else if ("subject".equals(key) || "object".equals(key) || "relation".equals(key) || "evidence".equals(key)) {
           Set<DirectedRelationshipType> closureTypes = new HashSet<>();
-          closureTypes.addAll(docUtil.DEFAULT_CLOSURE_TYPES);
+          closureTypes.addAll(SolrDocUtil.DEFAULT_CLOSURE_TYPES);
           if ("subject".equals(key) && query.getSubjectClosure() != null) {
             Set<DirectedRelationshipType> rels = resolveRelationships("subject_closure", query.getSubjectClosure());
             closureTypes.clear();
@@ -647,7 +652,7 @@ public class GolrLoader {
 
             // Add all equivalent IDs to subject
             List<Closure> closures = new ArrayList<>();
-            closures.add(closureUtil.getClosure((Node) value, docUtil.EQUIVALENT_EDGES));
+            closures.add(closureUtil.getClosure((Node) value, SolrDocUtil.EQUIVALENT_EDGES));
             docUtil.addClosure("subject_eq", ClosureUtil.collectIdClosure(closures), doc);
           }
           if ("object".equals(key) && query.getObjectClosure() != null) {
@@ -657,7 +662,7 @@ public class GolrLoader {
 
             // Add all equivalent IDs to object
             List<Closure> closures = new ArrayList<>();
-            closures.add(closureUtil.getClosure((Node) value, docUtil.EQUIVALENT_EDGES));
+            closures.add(closureUtil.getClosure((Node) value, SolrDocUtil.EQUIVALENT_EDGES));
             docUtil.addClosure("object_eq", ClosureUtil.collectIdClosure(closures), doc);
           }
           if ("relation".equals(key) && query.getRelationClosure() != null) {

--- a/src/main/java/org/monarch/golr/SolrDocUtil.java
+++ b/src/main/java/org/monarch/golr/SolrDocUtil.java
@@ -42,6 +42,8 @@ public class SolrDocUtil {
       new DirectedRelationshipType(OwlRelationships.RDFS_SUB_PROPERTY_OF, Direction.OUTGOING);
   static final Collection<DirectedRelationshipType> DEFAULT_CLOSURE_TYPES =
       ImmutableSet.of(EQUIVALENT_CLASS, SUBCLASS, TYPE, SAME_AS, SUBPROPERTY);
+  static final Collection<DirectedRelationshipType> EQUIVALENT_EDGES =
+      ImmutableSet.of(EQUIVALENT_CLASS, SAME_AS);
   
   private final ObjectMapper mapper = new ObjectMapper();
   private final ClosureUtil closureUtil;

--- a/src/main/java/org/monarch/golr/SolrDocUtil.java
+++ b/src/main/java/org/monarch/golr/SolrDocUtil.java
@@ -22,13 +22,13 @@ import com.google.common.collect.ImmutableSet;
 import io.scigraph.neo4j.DirectedRelationshipType;
 import io.scigraph.owlapi.OwlRelationships;
 
-public class SolrDocUtil {
+class SolrDocUtil {
     
-  static final String ID_SUFFIX = "";
-  static final String ID_CLOSURE_SUFFIX = "_closure";
-  static final String LABEL_SUFFIX = "_label";
-  static final String LABEL_CLOSURE_SUFFIX = "_closure_label";
-  static final String CLOSURE_MAP_SUFFIX = "_closure_map";
+  private static final String ID_SUFFIX = "";
+  private static final String ID_CLOSURE_SUFFIX = "_closure";
+  private static final String LABEL_SUFFIX = "_label";
+  private static final String LABEL_CLOSURE_SUFFIX = "_closure_label";
+  private static final String CLOSURE_MAP_SUFFIX = "_closure_map";
 
   private static final DirectedRelationshipType SUBCLASS =
       new DirectedRelationshipType(OwlRelationships.RDFS_SUBCLASS_OF, Direction.OUTGOING);
@@ -70,10 +70,7 @@ public class SolrDocUtil {
   }
   
   void addClosure(String fieldName, List<String> closures, SolrInputDocument solrDoc) {
-    Set<String> closureSet= new HashSet<String>();
-    for (String closure : closures){
-      closureSet.add(closure);
-    }
+    Set<String> closureSet = new HashSet<String>(closures);
     List<String> closureList = new ArrayList<String>(closureSet);
     solrDoc.addField(fieldName, closureList);
   }

--- a/src/test/java/org/monarch/golr/GolrLoadSetup.java
+++ b/src/test/java/org/monarch/golr/GolrLoadSetup.java
@@ -5,6 +5,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.scigraph.owlapi.OwlLabels;
 import org.junit.BeforeClass;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -73,6 +74,11 @@ public class GolrLoadSetup extends io.scigraph.util.GraphTestBase {
       forebrain.addLabel(Label.label("anatomical entity"));
       Relationship foo2forebrain = foo.createRelationshipTo(forebrain, RelationshipType.withName("http://purl.obolibrary.org/obo/RO_0002206"));
       foo2forebrain.setProperty(CommonProperties.IRI, "http://purl.obolibrary.org/obo/RO_0002206");
+
+      Node forebrainEq = createNode("x:forebrain");
+      forebrain.addLabel(Label.label("forebrain"));
+      forebrain.addLabel(Label.label("anatomical entity"));
+      forebrain.createRelationshipTo(forebrainEq, OwlRelationships.OWL_EQUIVALENT_CLASS);
 
       Node brain = createNode("http://purl.obolibrary.org/obo/UBERON_0000955");
       brain.addLabel(Label.label("brain"));

--- a/src/test/java/org/monarch/golr/GolrLoaderTest.java
+++ b/src/test/java/org/monarch/golr/GolrLoaderTest.java
@@ -95,7 +95,7 @@ public class GolrLoaderTest extends GolrLoadSetup {
   @Test
   public void customClosureQuery() throws Exception {
     GolrCypherQuery query = new GolrCypherQuery("MATCH path=(subject:gene)-[relation:`http://purl.obolibrary.org/obo/RO_0002206`]->(object:`anatomical entity`) RETURN DISTINCT path, subject, object, 'gene' AS subject_category, 'anatomy' AS object_category, 'direct' AS qualifier");
-    query.setObjectClosure("rdfs:subClassOf|http://purl.obolibrary.org/obo/BFO_0000050");
+    query.setObjectClosure("subClassOf|http://purl.obolibrary.org/obo/BFO_0000050");
     List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
     results = TestUtils.getResultList(query);
     TinkerGraphUtil tguEvidenceGraph = new TinkerGraphUtil(curieUtil);

--- a/src/test/java/org/monarch/golr/GolrLoaderTest.java
+++ b/src/test/java/org/monarch/golr/GolrLoaderTest.java
@@ -95,7 +95,7 @@ public class GolrLoaderTest extends GolrLoadSetup {
   @Test
   public void customClosureQuery() throws Exception {
     GolrCypherQuery query = new GolrCypherQuery("MATCH path=(subject:gene)-[relation:`http://purl.obolibrary.org/obo/RO_0002206`]->(object:`anatomical entity`) RETURN DISTINCT path, subject, object, 'gene' AS subject_category, 'anatomy' AS object_category, 'direct' AS qualifier");
-    query.setObjectClosure("subClassOf|http://purl.obolibrary.org/obo/BFO_0000050");
+    query.setObjectClosure("subClassOf|http://purl.obolibrary.org/obo/BFO_0000050|equivalentClass|sameAs");
     List<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
     results = TestUtils.getResultList(query);
     TinkerGraphUtil tguEvidenceGraph = new TinkerGraphUtil(curieUtil);

--- a/src/test/resources/fixtures/customClosureQuery.json
+++ b/src/test/resources/fixtures/customClosureQuery.json
@@ -12,7 +12,7 @@
   "subject_closure": ["http://x.org/gene"],
   "subject_closure_label": ["http://x.org/gene"],
   "subject_closure_map": "{\"http://x.org/gene\":\"http://x.org/gene\"}",
-  "object_eq": ["http://purl.obolibrary.org/obo/UBERON_0001890"],
+  "object_eq": ["http://purl.obolibrary.org/obo/UBERON_0001890", "x:forebrain"],
   "object": ["http://purl.obolibrary.org/obo/UBERON_0001890"],
   "object_label": ["http://purl.obolibrary.org/obo/UBERON_0001890"],
   "object_closure": ["http://purl.obolibrary.org/obo/UBERON_0001062", "http://purl.obolibrary.org/obo/UBERON_0000955", "http://x.org/body_part", "http://purl.obolibrary.org/obo/UBERON_0001890", "http://purl.obolibrary.org/obo/UBERON_0000033"],

--- a/src/test/resources/fixtures/customClosureQuery.json
+++ b/src/test/resources/fixtures/customClosureQuery.json
@@ -15,8 +15,8 @@
   "object_eq": ["http://purl.obolibrary.org/obo/UBERON_0001890", "x:forebrain"],
   "object": ["http://purl.obolibrary.org/obo/UBERON_0001890"],
   "object_label": ["http://purl.obolibrary.org/obo/UBERON_0001890"],
-  "object_closure": ["http://purl.obolibrary.org/obo/UBERON_0001062", "http://purl.obolibrary.org/obo/UBERON_0000955", "http://x.org/body_part", "http://purl.obolibrary.org/obo/UBERON_0001890", "http://purl.obolibrary.org/obo/UBERON_0000033"],
-  "object_closure_label": ["http://purl.obolibrary.org/obo/UBERON_0001062", "http://purl.obolibrary.org/obo/UBERON_0000955", "http://x.org/body_part", "http://purl.obolibrary.org/obo/UBERON_0001890", "http://purl.obolibrary.org/obo/UBERON_0000033"],
-  "object_closure_map": "{\"http://purl.obolibrary.org/obo/UBERON_0001062\":\"http://purl.obolibrary.org/obo/UBERON_0001062\",\"http://purl.obolibrary.org/obo/UBERON_0000955\":\"http://purl.obolibrary.org/obo/UBERON_0000955\",\"http://x.org/body_part\":\"http://x.org/body_part\",\"http://purl.obolibrary.org/obo/UBERON_0001890\":\"http://purl.obolibrary.org/obo/UBERON_0001890\",\"http://purl.obolibrary.org/obo/UBERON_0000033\":\"http://purl.obolibrary.org/obo/UBERON_0000033\"}",
+  "object_closure": ["x:forebrain", "http://purl.obolibrary.org/obo/UBERON_0001062", "http://purl.obolibrary.org/obo/UBERON_0000955", "http://x.org/body_part", "http://purl.obolibrary.org/obo/UBERON_0001890", "http://purl.obolibrary.org/obo/UBERON_0000033"],
+  "object_closure_label": ["x:forebrain", "http://purl.obolibrary.org/obo/UBERON_0001062", "http://purl.obolibrary.org/obo/UBERON_0000955", "http://x.org/body_part", "http://purl.obolibrary.org/obo/UBERON_0001890", "http://purl.obolibrary.org/obo/UBERON_0000033"],
+  "object_closure_map": "{\"x:forebrain\":\"x:forebrain\",\"http://purl.obolibrary.org/obo/UBERON_0001062\":\"http://purl.obolibrary.org/obo/UBERON_0001062\",\"http://purl.obolibrary.org/obo/UBERON_0000955\":\"http://purl.obolibrary.org/obo/UBERON_0000955\",\"http://x.org/body_part\":\"http://x.org/body_part\",\"http://purl.obolibrary.org/obo/UBERON_0001890\":\"http://purl.obolibrary.org/obo/UBERON_0001890\",\"http://purl.obolibrary.org/obo/UBERON_0000033\":\"http://purl.obolibrary.org/obo/UBERON_0000033\"}",
   "object_category": "anatomy"
 }

--- a/src/test/resources/fixtures/customClosureQuery.json
+++ b/src/test/resources/fixtures/customClosureQuery.json
@@ -1,1 +1,22 @@
-{"subject_category":"gene","qualifier":"direct","subject_gene":["http://x.org/gene"],"subject_gene_label":["http://x.org/gene"],"subject_gene_closure":["http://x.org/gene"],"subject_gene_closure_label":["http://x.org/gene"],"subject_gene_closure_map":"{\"http://x.org/gene\":\"http://x.org/gene\"}","subject_ortholog_closure":["http://x.org/gene_ortholog"],"subject":["http://x.org/gene"],"subject_label":["http://x.org/gene"],"subject_closure":["http://x.org/gene"],"subject_closure_label":["http://x.org/gene"],"subject_closure_map":"{\"http://x.org/gene\":\"http://x.org/gene\"}","object":["http://purl.obolibrary.org/obo/UBERON_0001890"],"object_label":["http://purl.obolibrary.org/obo/UBERON_0001890"],"object_closure":["http://purl.obolibrary.org/obo/UBERON_0001890","http://purl.obolibrary.org/obo/UBERON_0000955","http://purl.obolibrary.org/obo/UBERON_0000033","http://x.org/body_part","http://purl.obolibrary.org/obo/UBERON_0001062"],"object_closure_label":["http://purl.obolibrary.org/obo/UBERON_0001890","http://purl.obolibrary.org/obo/UBERON_0000955","http://purl.obolibrary.org/obo/UBERON_0000033","http://x.org/body_part","http://purl.obolibrary.org/obo/UBERON_0001062"],"object_closure_map":"{\"http://purl.obolibrary.org/obo/UBERON_0001062\":\"http://purl.obolibrary.org/obo/UBERON_0001062\",\"http://purl.obolibrary.org/obo/UBERON_0000955\":\"http://purl.obolibrary.org/obo/UBERON_0000955\",\"http://x.org/body_part\":\"http://x.org/body_part\",\"http://purl.obolibrary.org/obo/UBERON_0001890\":\"http://purl.obolibrary.org/obo/UBERON_0001890\",\"http://purl.obolibrary.org/obo/UBERON_0000033\":\"http://purl.obolibrary.org/obo/UBERON_0000033\"}","object_category":"anatomy"}
+{
+  "subject_category": "gene",
+  "qualifier": "direct",
+  "subject_gene": ["http://x.org/gene"],
+  "subject_gene_label": ["http://x.org/gene"],
+  "subject_gene_closure": ["http://x.org/gene"],
+  "subject_gene_closure_label": ["http://x.org/gene"],
+  "subject_gene_closure_map": "{\"http://x.org/gene\":\"http://x.org/gene\"}",
+  "subject_ortholog_closure": ["http://x.org/gene_ortholog"],
+  "subject": ["http://x.org/gene"],
+  "subject_label": ["http://x.org/gene"],
+  "subject_closure": ["http://x.org/gene"],
+  "subject_closure_label": ["http://x.org/gene"],
+  "subject_closure_map": "{\"http://x.org/gene\":\"http://x.org/gene\"}",
+  "object_eq": ["http://purl.obolibrary.org/obo/UBERON_0001890"],
+  "object": ["http://purl.obolibrary.org/obo/UBERON_0001890"],
+  "object_label": ["http://purl.obolibrary.org/obo/UBERON_0001890"],
+  "object_closure": ["http://purl.obolibrary.org/obo/UBERON_0001062", "http://purl.obolibrary.org/obo/UBERON_0000955", "http://x.org/body_part", "http://purl.obolibrary.org/obo/UBERON_0001890", "http://purl.obolibrary.org/obo/UBERON_0000033"],
+  "object_closure_label": ["http://purl.obolibrary.org/obo/UBERON_0001062", "http://purl.obolibrary.org/obo/UBERON_0000955", "http://x.org/body_part", "http://purl.obolibrary.org/obo/UBERON_0001890", "http://purl.obolibrary.org/obo/UBERON_0000033"],
+  "object_closure_map": "{\"http://purl.obolibrary.org/obo/UBERON_0001062\":\"http://purl.obolibrary.org/obo/UBERON_0001062\",\"http://purl.obolibrary.org/obo/UBERON_0000955\":\"http://purl.obolibrary.org/obo/UBERON_0000955\",\"http://x.org/body_part\":\"http://x.org/body_part\",\"http://purl.obolibrary.org/obo/UBERON_0001890\":\"http://purl.obolibrary.org/obo/UBERON_0001890\",\"http://purl.obolibrary.org/obo/UBERON_0000033\":\"http://purl.obolibrary.org/obo/UBERON_0000033\"}",
+  "object_category": "anatomy"
+}


### PR DESCRIPTION
Adds equivalent|same as closures for subjects and objects.  Also made a small adjustment for taxon inferencing to search has_part! in both directions instead of outgoing edges.