### PR TITLE
Protect against curies without a local identifier

### DIFF
--- a/src/main/java/org/monarch/golr/SimpleLoader.java
+++ b/src/main/java/org/monarch/golr/SimpleLoader.java
@@ -91,11 +91,18 @@ class SimpleLoader {
           continue;
         }
 
-        generator.writeStartObject();
-        generator.writeStringField("id", curieUtil.getCurie(iri).orElse(iri));
-        String[] curieParts = curie.get().split(":");
+        String[] curieParts;
+        curieParts = curie.get().split(":");
+        if (curieParts.length == 1) {
+          logger.info("Curie does not have colon");
+          logger.info(curie.get());
+          continue;
+        }
+
         String prefix = curieParts[0];
         String reference = curieParts[1];
+        generator.writeStartObject();
+        generator.writeStringField("id", curieUtil.getCurie(iri).orElse(iri));
         generator.writeStringField("prefix", prefix);
 
         try{

--- a/src/main/java/org/monarch/golr/SimpleLoader.java
+++ b/src/main/java/org/monarch/golr/SimpleLoader.java
@@ -94,7 +94,7 @@ class SimpleLoader {
         String[] curieParts;
         curieParts = curie.get().split(":");
         if (curieParts.length == 1) {
-          logger.info("Curie does not have colon");
+          logger.info("Curie does not have reference");
           logger.info(curie.get());
           continue;
         }


### PR DESCRIPTION
Protect against curies without a local identifier (reference), eg https://github.com/monarch-initiative/dipper/issues/967

fixes #57 